### PR TITLE
楽天レシピのカテゴリ取得用テーブルの作成 #77

### DIFF
--- a/src/app/Category.php
+++ b/src/app/Category.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Category extends Model
+{
+    protected $fillable = [
+        'id',
+        'name',
+    ];
+
+    public function subCategory()
+    {
+        return $this->hasMany('App\SubCategory');
+    }
+}

--- a/src/app/SubCategory.php
+++ b/src/app/SubCategory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class SubCategory extends Model
+{
+    protected $fillable = [
+        'id',
+        'categoryId',
+        'name',
+    ];
+
+    public function category()
+    {
+        return $this->belongsTo('App\Category');
+    }
+}

--- a/src/database/migrations/2022_06_23_070149_create_categories_table.php
+++ b/src/database/migrations/2022_06_23_070149_create_categories_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateCategoriesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('categories', function (Blueprint $table) {
+            $table->BigInteger('id')->unsigned()->primary();
+            $table->text('name');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('categories');
+    }
+}

--- a/src/database/migrations/2022_06_23_070227_create_sub_categories_table.php
+++ b/src/database/migrations/2022_06_23_070227_create_sub_categories_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateSubCategoriesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('sub_categories', function (Blueprint $table) {
+            $table->BigInteger('id')->unsigned()->primary();
+            $table->BigInteger('categoryId')->unsigned();
+            $table->foreign('categoryId')->references('id')->on('categories')->onDelete('cascade');
+            $table->text('name');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('sub_categories');
+    }
+}


### PR DESCRIPTION
why
楽天apiからレシピカテゴリを取得し、データベースに保存する処理の準備をするため

what
- category、subCategoryのテーブルとモデルを作成
- それぞれのテーブルとモデルの内容を修正
- migration処理