### PR TITLE
投稿レシピの手順の更新(登録)処理の実装の準備 #125

### DIFF
--- a/src/app/Procedure.php
+++ b/src/app/Procedure.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Procedure extends Model
+{
+    protected $fillable = [
+        'post_recipe_id',
+        'order',
+        'photo',
+        'procedure'
+    ];
+
+    public function post(): BelongsTo
+    {
+        return $this->belongsTo('App\Post');
+    }
+}

--- a/src/database/migrations/2022_06_29_033110_create_procedures_table.php
+++ b/src/database/migrations/2022_06_29_033110_create_procedures_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateProceduresTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('procedures', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->bigInteger('post_id')->unsigned();
+            $table->foreign('post_id')->references('id')->on('posts')->onDelete('cascade');
+            $table->integer('order');
+            $table->text('photo')->nullable();
+            $table->text('procedure');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('procedures');
+    }
+}


### PR DESCRIPTION
why
投稿レシピの手順をデータベースに保存するため

what
- procedureテーブルとモデルを作成
- procedureテーブルとモデルを修正
- migrate