### PR TITLE
投稿レシピの投稿画面の戻るボタンの実装 #155

### DIFF
--- a/src/resources/views/post/pages/material/edit.blade.php
+++ b/src/resources/views/post/pages/material/edit.blade.php
@@ -6,7 +6,7 @@
     <div class="card col-md-auto col-lg-auto material-register-form">
         <div class="card-body">
             {{-- 戻るボタン --}}
-            <a class="btn button-back" href="{{-- {{ route('materialCreate.back', ['materialCreate' => $postId]) }} --}}">>>戻る</a>
+            <a class="btn button-back" href="{{ route('post.edit', ['post' => $postId]) }}">>>戻る</a>
             <br />
             {{-- 登録完了メッセージ --}}
             @include('post.pages.material.components.successMessage')

--- a/src/resources/views/post/pages/procedure/edit.blade.php
+++ b/src/resources/views/post/pages/procedure/edit.blade.php
@@ -6,7 +6,7 @@
     <div class="card col-md-auto col-lg-auto material-register-form">
         <div class="card-body">
             {{-- 戻るボタン --}}
-            <a class="btn button-back" href="{{-- {{ route('materialCreate.back', ['materialCreate' => $postId]) }} --}}">>>戻る</a>
+            <a class="btn button-back" href="{{ route('post.edit', ['post' => $postId]) }}">>>戻る</a>
             <br />
             {{-- 登録完了メッセージ --}}
             @include('post.pages.procedure.components.successMessage')


### PR DESCRIPTION
why
材料・手順の登録画面から全体の編集画面に戻るため

what
- bladeに戻るボタンの追加
- リンクの追加