### PR TITLE
Googleのソーシャルログインを可能にする #183

### DIFF
--- a/src/app/Http/Controllers/Auth/LoginController.php
+++ b/src/app/Http/Controllers/Auth/LoginController.php
@@ -4,6 +4,8 @@ namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
 use App\Providers\RouteServiceProvider;
+use App\User;
+use Illuminate\Http\Request;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
 use Laravel\Socialite\Facades\Socialite;
 
@@ -42,5 +44,18 @@ class LoginController extends Controller
     public function redirectToProvider($provider)
     {
         return Socialite::driver($provider)->redirect();
+    }
+
+    public function handleProviderCallback(Request $request, $provider)
+    {
+        $providerUser = Socialite::driver($provider)->stateless()->user();
+        $user = User::where('email', $providerUser->getEmail())->first();
+
+        if ($user) {
+            $this->guard()->login($user, true);
+            return $this->sendLoginResponse($request);
+        }
+
+        // return redirect()->route('register.{provider}', compact('provider', 'email', 'token'));
     }
 }

--- a/src/routes/web.php
+++ b/src/routes/web.php
@@ -33,6 +33,7 @@ Auth::routes();
 ==================== */
 Route::prefix('login')->name('login.')->group(function () {
     Route::get('/{provider}', 'Auth\LoginController@redirectToProvider')->name('{provider}');
+    Route::get('/{provider}/callback', 'Auth\LoginController@handleProviderCallback')->name('{provider}.callback');
 });
 /* ====================
     Admin 認証不要


### PR DESCRIPTION
why
ソーシャルログイン実装のため

what
- rootの追加
- LoginControllerにメソッドを追加
- Googleからユーザー情報を取得
- Googleのメールアドレスを元にユーザーモデルを取得
- ログイン処理の実装