### PR TITLE
調味料登録ページのエラーメッセージとサクセスメッセージの表示 #238

### DIFF
--- a/src/resources/views/post/pages/material/components/registerSeasoning.blade.php
+++ b/src/resources/views/post/pages/material/components/registerSeasoning.blade.php
@@ -3,20 +3,7 @@
     <p class="col">調味料の新規登録</p>
     <div class="col-1"></div>
 </div>
-{{-- @if($errors->has('store_seasoning'))
-    <div class="row cols-3 spacing-reset">
-        <div class="col-1"></div>
-        <p class="col alert-message-error">※{{ $errors->first('store_seasoning') }}</p>
-        <div class="col-1"></div>
-    </div>
-@endif
-@if($errors->has('store_seasoning_quantity'))
-    <div class="row cols-3 spacing-reset">
-        <div class="col-1"></div>
-        <p class="col alert-message-error">※{{ $errors->first('store_seasoning_quantity') }}</p>
-        <div class="col-1"></div>
-    </div>
-@endif --}}
+@include('post.pages.material.message.registerSeasoningError')
 <form method="POST" action="{{ route('post.seasoning.store') }}" id="store-seasoning">
     @csrf
     <div class="material">

--- a/src/resources/views/post/pages/material/message/registerSeasoningError.blade.php
+++ b/src/resources/views/post/pages/material/message/registerSeasoningError.blade.php
@@ -1,0 +1,14 @@
+@if($errors->has('store_seasoning'))
+    <div class="row cols-3 spacing-reset">
+        <div class="col-1"></div>
+        <p class="col alert-message-error">※{{ $errors->first('store_seasoning') }}</p>
+        <div class="col-1"></div>
+    </div>
+@endif
+@if($errors->has('store_seasoning_quantity'))
+    <div class="row cols-3 spacing-reset">
+        <div class="col-1"></div>
+        <p class="col alert-message-error">※{{ $errors->first('store_seasoning_quantity') }}</p>
+        <div class="col-1"></div>
+    </div>
+@endif


### PR DESCRIPTION
why

- 調味料登録ページのエラーメッセージとサクセスメッセージの表示するため
- ユーザーにエラー発生原因を知らせるため

what

- サクセスメッセージ用のbladeの作成
- エラーメッセージ用のbladeの作成
- bladeの修正