### PR TITLE
人数登録・更新ページのエラーメッセージとサクセスメッセージの表示 #268

### DIFF
--- a/src/app/Http/Controllers/PostController.php
+++ b/src/app/Http/Controllers/PostController.php
@@ -134,11 +134,11 @@ class PostController extends Controller
     public function peopleStore(PeopleRequest $request)
     {
 
-        $postRecipe =  Post::where('id', $request->post_id)->first();
-        // ->where('user_id', $request->user)->first();
+        $postRecipe =  Post::where('id', $request->post_id)->where('user_id', $request->user)->first();
+
         $postRecipe->people = $request->people;
         $postRecipe->save();
-        return redirect()->route('post.material.show', ['post' => $request->post_id])->with('completion-of-registration-people', '登録が完了しました。');
+        return redirect()->route('post.material.show', ['post' => $request->post_id])->with('completion-of-registration-people', '登録が完了しました');
     }
 
     public function procedureShow($post)

--- a/src/app/Http/Requests/PeopleRequest.php
+++ b/src/app/Http/Requests/PeopleRequest.php
@@ -26,14 +26,14 @@ class PeopleRequest extends FormRequest
         return [
             'post_id' => 'required',
             'user' => 'required',
-            'update_people' => 'required|numeric|max:20',
+            'people' => 'required|numeric|max:20',
         ];
     }
 
     public function attributes()
     {
         return [
-            'update_people' => '人数'
+            'people' => '人数'
         ];
     }
 }

--- a/src/resources/views/post/pages/material/components/registerPeople.blade.php
+++ b/src/resources/views/post/pages/material/components/registerPeople.blade.php
@@ -5,13 +5,9 @@
         <p class="col">何人分の材料か登録</p>
         <div class="col-1"></div>
     </div>
-    {{-- @if($errors->has('update_people'))
-        <div class="row cols-3 spacing-reset">
-            <div class="col-1"></div>
-            <p class="col alert-message-error">※{{ $errors->first('update_people') }}</p>
-            <div class="col-1"></div>
-        </div>
-    @endif --}}
+    @include('post.pages.material.message.registerPeopleError')
+
+
     <div class="row cols-3 spacing-reset material-form">
         <div class="col-1"></div>
         <input

--- a/src/resources/views/post/pages/material/message/registerPeopleError.blade.php
+++ b/src/resources/views/post/pages/material/message/registerPeopleError.blade.php
@@ -1,0 +1,7 @@
+@if($errors->has('people'))
+    <div class="row cols-3 spacing-reset">
+        <div class="col-1"></div>
+        <p class="col alert-message-error">※{{ $errors->first('people') }}</p>
+        <div class="col-1"></div>
+    </div>
+@endif


### PR DESCRIPTION
why
人数登録・更新ページのエラーメッセージとサクセスメッセージの表示のため

what

- サクセスメッセージ用のbladeの作成
- エラーメッセージ用のbladeの作成
- bladeの修正