### PR TITLE
mypage(setting)のメールアドレスの変更処理のエラーメッセージ・サクセスメッセージの表示 #300

### DIFF
--- a/src/app/Http/Controllers/SettingController.php
+++ b/src/app/Http/Controllers/SettingController.php
@@ -17,6 +17,6 @@ class SettingController extends Controller
     {
 
         $user->fill($request->all())->save();
-        return redirect()->route('setting.index');
+        return redirect()->route('setting.index')->with('completion-of-update-email', 'メールアドレスの更新が完了しました。');
     }
 }

--- a/src/resources/views/mypage/setting/index.blade.php
+++ b/src/resources/views/mypage/setting/index.blade.php
@@ -8,6 +8,8 @@
 @section('main')
     <h1 class="mypage-title">Setting</h1>
     <h2 class="mypage-subtitle">メールアドレスの変更</h2>
+    @include('mypage.setting.message.updateEmailError')
+    @include('mypage.setting.message.successMessage')
     <div class="setting-email">
         <div class="setting-block">
             <p class="setting-title">現在のメールアドレス</p>

--- a/src/resources/views/mypage/setting/message/successMessage.blade.php
+++ b/src/resources/views/mypage/setting/message/successMessage.blade.php
@@ -1,0 +1,7 @@
+@if (session('completion-of-update-email'))
+    <div class="row spacing-reset">
+        <div class="alert alert-message-success col" role="alert">
+            {{ session('completion-of-update-email') }}
+        </div>
+    </div>
+@endif

--- a/src/resources/views/mypage/setting/message/updateEmailError.blade.php
+++ b/src/resources/views/mypage/setting/message/updateEmailError.blade.php
@@ -1,0 +1,3 @@
+@if($errors->has('email'))
+    <p class="col alert-message-error">※{{ $errors->first('email') }}</p>
+@endif


### PR DESCRIPTION
why
エラーメッセージと更新完了メッセージを表示するため

what

- bladeの作成
- bladeの編集
- Controllerの修正