### PR TITLE
パスワード再設定メール(テキスト版)の送信処理の作成 #337

### DIFF
--- a/src/app/Mail/BareMail.php
+++ b/src/app/Mail/BareMail.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+
+class BareMail extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    /**
+     * Create a new message instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Build the message.
+     *
+     * @return $this
+     */
+    public function build()
+    {
+        return $this;
+    }
+}

--- a/src/app/Notifications/PasswordResetNotification.php
+++ b/src/app/Notifications/PasswordResetNotification.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Mail\BareMail;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class PasswordResetNotification extends Notification
+{
+    use Queueable;
+
+    public $token;
+    public $mail;
+
+    /**
+     * Create a new notification instance.
+     *
+     * @return void
+     */
+    public function __construct(string $token, BareMail $mail)
+    {
+        $this->token = $token;
+        $this->mail = $mail;
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function via($notifiable)
+    {
+        return ['mail'];
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return \Illuminate\Notifications\Messages\MailMessage
+     */
+    public function toMail($notifiable)
+    {
+        return $this->mail
+            ->from(config('mail.from.address'), config('mail.from.name'))
+            ->to($notifiable->email)
+            ->subject('[memo]パスワード再設定')
+            ->text('emails.password_reset')
+            ->with([
+                'url' => route('password.reset', [
+                    'token' => $this->token,
+                    'email' => $notifiable->email,
+                ]),
+                'count' => config(
+                    'auth.passwords.' .
+                    config('auth.defaults.passwords') .
+                    '.expire'
+                ),
+            ]);
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return array
+     */
+    public function toArray($notifiable)
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/src/app/User.php
+++ b/src/app/User.php
@@ -2,6 +2,8 @@
 
 namespace App;
 
+use App\Mail\BareMail;
+use App\Notifications\PasswordResetNotification;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -99,4 +101,11 @@ class User extends Authenticatable
         return $this->followings()->count();
     }
 
+    /**
+     * カスタマイズしたテキストメールをパスワード再設定メールで送信
+     */
+    public function sendPasswordResetNotification($token)
+    {
+        $this->notify(new PasswordResetNotification($token, new BareMail()));
+    }
 }


### PR DESCRIPTION
why
パスワード再設定メール(テキスト版)の送信処理の作成のため

what

- Mailableクラスを継承したクラスの作成
- 通知クラスの作成
- Userモデルへのメソッド追加